### PR TITLE
Bind to click events by default, bind to touch events only if supported

### DIFF
--- a/src/jquery.navobile.js
+++ b/src/jquery.navobile.js
@@ -42,7 +42,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         base.$content.data({
           drag: false
         });
-        base.bindTap(base.$cta, base.$nav, base.$content, ($('html').hasClass('touch') ? 'touchend' : 'click'));
+        base.bindTap(base.$cta, base.$nav, base.$content, 'click');
+        if ($('html').hasClass('touch')) {
+          base.bindTap(base.$cta, base.$nav, base.$content, 'touchend');
+        }
         if (typeof Hammer === 'function' && (base.options.bindSwipe || base.options.bindDrag)) {
           hammerObject = Hammer(base.$content, base.options.hammerOptions);
           if (base.options.bindSwipe) {


### PR DESCRIPTION
Because devices can have both a mouse AND a touchscreen. Click wasn't working for these devices. This fixes it because it binds to click events by default and additionally binds to touch events if touch is supported.